### PR TITLE
[Fix] rfk::Object had copy and move constructors, but no copy and mov…

### DIFF
--- a/Refureku/Library/Include/Refureku/Object.h
+++ b/Refureku/Library/Include/Refureku/Object.h
@@ -26,5 +26,8 @@ namespace rfk
 			virtual ~Object()		= default;
 
 			virtual	Struct const& getArchetype() const noexcept = 0;
+			
+			Object& operator=(Object const&) 	= default;
+			Object& operator=(Object&&) 		= default;
 	};
 }


### PR DESCRIPTION
 rfk::Object had copy and move constructors, but no copy and move assignements. 
In other words, children of rfk::Object could not be moved or copied by assignement.

Currently, the following code does not compile if MyObject inherits rfk::Object.
```cpp
MyObject o;
MyObject b;
b = std::move(o)
```
This merge fixes it.